### PR TITLE
[SCI-2606][NGX] Y-Axis on View Spectra Page scaling issue

### DIFF
--- a/src/main/java/com/jjoe64/graphview/GridLabelRenderer.java
+++ b/src/main/java/com/jjoe64/graphview/GridLabelRenderer.java
@@ -725,7 +725,7 @@ public class GridLabelRenderer {
         }
 
         double minY = mGraphView.getViewport().getMinY(false);
-        double maxY = mGraphView.getViewport().getMaxY(false);
+        double maxY = mGraphView.getViewport().getMaxY(true);
 
         if (minY == maxY) {
             return false;


### PR DESCRIPTION
Changes details:
Maximum Y-axis value is now getting for the complete range of all series, not just for visible ones.

![spectra-scrolling](https://user-images.githubusercontent.com/51589884/78544351-ae6f0300-7802-11ea-929f-387127623c69.gif)
